### PR TITLE
Updated dependencies for diffusers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .ipynb_checkpoints/
+test.ipynb

--- a/accelerate.nix
+++ b/accelerate.nix
@@ -28,12 +28,12 @@
 }:
 buildPythonPackage rec {
   pname = "accelerate";
-  version = "0.12.0";
+  version = "0.14.0";
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-W0tFFX+ryHUK/hRHFXY3YfrHejfPwwk5xKomwSCJJvM=";
+    sha256 = "sha256-ov/PSrqofcEDWACOHEO7NgX2oC+iWeIXHF6PXA/mXLU=";
   };
 
   propagatedBuildInputs = [

--- a/diffusers.nix
+++ b/diffusers.nix
@@ -24,12 +24,12 @@
 }:
 buildPythonPackage rec {
   pname = "diffusers";
-  version = "0.3.0";
+  version = "0.11.1";
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-mYm7rssVoAECHwzHmyxMHOyM/hDo3KghACmBiblsG1Q=";
+    sha256 = "sha256-1BIno5rS2oaMnmUsEDIP3RnUyRhq146WLhONFb1hL9I=";
   };
 
   propagatedBuildInputs = [

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -201,6 +201,7 @@
       "original": {
         "owner": "tweag",
         "repo": "jupyterWith",
+        "rev": "0b7f2e843f023c89283daf53eabce322efc9ca7c",
         "type": "github"
       }
     },
@@ -288,11 +289,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1662096612,
-        "narHash": "sha256-R+Q8l5JuyJryRPdiIaYpO5O3A55rT+/pItBrKcy7LM4=",
+        "lastModified": 1672057183,
+        "narHash": "sha256-GN7/10DNNvs1FPj9tlZA2qgNdFuYKKuS3qlHTqAxasQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21de2b973f9fee595a7a1ac4693efff791245c34",
+        "rev": "b139e44d78c36c69bcbb825b20dbfa51e7738347",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "JupyterLab Flake for Stable Diffusion";
 
   inputs = {
-    jupyterWith.url = "github:tweag/jupyterWith";
+    jupyterWith.url = "github:tweag/jupyterWith?rev=0b7f2e843f023c89283daf53eabce322efc9ca7c";
     flake-utils.url = "github:numtide/flake-utils";
     nixgl.url = "github:guibou/nixGL";
   };
@@ -30,7 +30,7 @@
 
       iPython = pkgs.kernels.iPythonWith {
         name = "Python-env";
-        packages = p: with p; [diffusers transformers ftfy];
+        packages = p: with p; [diffusers accelerate transformers ftfy];
         ignoreCollisions = true;
       };
 

--- a/stable-diff.ipynb
+++ b/stable-diff.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "prompt = \"a photo of an astronaught riding a horse on mars\"\n",
     "with autocast(\"cuda\"):\n",
-    "    image = pipe(prompt)[\"sample\"][0]  \n",
+    "    image = pipe(prompt).images[0]  \n",
     "\n",
     "display(image)"
    ]
@@ -96,7 +96,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Major Changes:
- Updated diffusers 0.3.0 -> 0.11.1
- Updated accelerate 0.12.0 -> 0.14.0
- Locked jupyterWith to current revision due to breaking changes on with their overhaul.
- Changed syntax in inference call to fix breakage due to version change.

Minor Changes:
- Added notebook to test output in .gitignore
- Updated flake dependencies (minus jupyterWith)